### PR TITLE
update doi to datacite standards

### DIFF
--- a/R/add_publication_from_unpaywall.R
+++ b/R/add_publication_from_unpaywall.R
@@ -107,7 +107,7 @@ add_publication_from_unpaywall <- function(publication_table_id,
           pmid <- NA
         }
 
-        doi_url <- glue::glue("www.doi.org/{doi}")
+        doi_url <- glue::glue("https://www.doi.org/{doi}")
 
         #return metadata
         new_data <- tibble::tibble("title"=title, "journal"=journal, "author" = author_list, "year"=year, "pmid" = pmid, "doi"=doi_url,


### PR DESCRIPTION
Minor change - one of the two add_publications functions was giving the wrong doi. Probably should have a `create_datacite_doi` function or something that handles this rather than handling it twice in the two different functions, but maybe not worth the extra complexity...