### PR TITLE
Fix outdated test expectations

### DIFF
--- a/tests/testthat/test_json_schema_utils.R
+++ b/tests/testthat/test_json_schema_utils.R
@@ -41,7 +41,11 @@ test_that("Recursive lookup works with `get_dependency_from_json_schema`", {
          "specimenPreparationMethod",
          "tissue",
          "tumorType",
-         "entityId")
+         "entityId",
+         "transplantationType",
+         "transplantationRecipientSpecies",
+         "transplantationRecipientTissue",
+         "isXenograft")
   
   k_test <- get_dependency_from_json_schema(id = "bts:GenomicsAssayTemplate") 
   testthat::expect_equal(sort(k), sort(k_test))


### PR DESCRIPTION
We updated a template in the data model without updating the test expectations, so of course the test failed. 

This ONLY updates a test. 