### PR TITLE
Pin pandas to 1.5.3 bc of breaking changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
     libxml2-dev
 
 
-RUN pip install --break-system-packages pandas synapseclient==2.7.0
+RUN pip install --break-system-packages pandas==1.5.3 synapseclient==2.7.0
 
 COPY . /nfportalutils
 


### PR DESCRIPTION
Using the latest build downstream led to a test job running unsuccessfully because of pandas 2.0, which has a lot of breaking changes: https://pandas.pydata.org/docs/whatsnew/v2.0.0.html#backwards-incompatible-api-changes -- the main one here is the `line_terminator` one, which previously had a deprecation warning and will now give an error if one tries to upload a table:
`Error : TypeError: NDFrame.to_csv() got an unexpected keyword argument 'line_terminator'`