### PR TITLE
Update annotations.R

### DIFF
--- a/R/annotations.R
+++ b/R/annotations.R
@@ -21,7 +21,7 @@ annotate_with_manifest <- function(manifest, ignore_na = TRUE, ignore_blank = TR
   filterBlank <- if(ignore_blank) function(x) !any(x == "") else TRUE # same as above
   annotations <- lapply(annotations, function(x) Filter(function(x) filterNA(x) & filterBlank(x) & length(x), unlist(x, recursive = F)))
   for(entity in names(annotations)) {
-    .syn$setAnnotations(entity = entity, annotations = as.list(annotations[[entity]]))
+    .syn$set_annotations(entity = entity, annotations = as.list(annotations[[entity]]))
   }
   if (verbose) message("Annotations submitted")
 }


### PR DESCRIPTION
Update `setAnnotations` method to `set_annotations` to avoid the deprecation warning and future breaks:

```
DeprecationWarning: Call to deprecated method setAnnotations. (deprecated and replaced with :py:meth:`set_annotations` This method is UNSAFE and may overwrite existing annotations without confirming that you have retrieved and updated the latest annotations) -- Deprecated since version 2.1.0.
  args, kwargs)
```