### PR TITLE
Patch/schematic api

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nfportalutils
 Title: NF Portal Utilities
-Version: 0.0.0.945
+Version: 0.0.0.946
 Authors@R: c(
     person(given = "Robert", family = "Allaway", role = c("aut", "cre"),
            email = "robert.allaway@sagebionetworks.org",

--- a/R/annotation_qc.R
+++ b/R/annotation_qc.R
@@ -35,9 +35,8 @@ manifest_generate <- function(data_type,
                      use_annotations = use_annotations,
                      dataset_id = dataset_id,
                      asset_view = asset_view,
-                     output_format = output_format_param,
-                     access_token = access_token
-                   ))
+                     output_format = output_format_param),
+                   httr::add_headers(Authorization = paste("Bearer", access_token)))
 
   status <- httr::status_code(req)
   if(status != 200L) stop("Unsuccessful request, received status code: ", status)

--- a/R/annotation_qc.R
+++ b/R/annotation_qc.R
@@ -1,7 +1,7 @@
 #' Generate manifest via schematic service
 #'
 #' See [schematic manifest generation](https://schematic.api.sagebionetworks.org/v1/ui/#/Manifest%20Operations/schematic_api.api.routes.get_manifest_route).
-#' Note that this uses the access token of user that should already by logged in with `syn_login`.
+#' Note that this uses the access token of user that should already be logged in with `syn_login`.
 #'
 #' @param data_type Data type of the manifest to generate (aka Component).
 #' @param dataset_id Optional, if given this fills out manifest for existing dataset instead of generating a blank manifest.
@@ -22,7 +22,7 @@ manifest_generate <- function(data_type,
                               use_annotations = TRUE,
                               service = "https://schematic.api.sagebionetworks.org/v1/manifest/generate") {
 
-  # yes, param has been re-encoded like this for 'dataframe'
+  # yes, param needs to be re-encoded like this for 'dataframe'
   output_format_param <- if (output_format == "dataframe") "dataframe (only if getting existing manifests)" else output_format
   access_token <- .syn$credentials$secret
   use_annotations <- tolower(as.character(use_annotations))

--- a/man/manifest_generate.Rd
+++ b/man/manifest_generate.Rd
@@ -38,5 +38,5 @@ For excel, path to local file; for google_sheet, URL to sheet; for dataframe, JS
 }
 \description{
 See \href{https://schematic.api.sagebionetworks.org/v1/ui/#/Manifest\%20Operations/schematic_api.api.routes.get_manifest_route}{schematic manifest generation}.
-Note that this uses the access token of user that should already by logged in with \code{syn_login}.
+Note that this uses the access token of user that should already be logged in with \code{syn_login}.
 }


### PR DESCRIPTION
One of of the two endpoints we wrap (`manifest_generate`) needs to be updated with schematic changes announced this morning, so if you are using this then please reinstall package after this is merged. Close #127.

Test:
```
library(nfportalutils)
syn_login(Sys.getenv("SYNAPSE_AUTH_TOKEN"))
`manifest_generate("ImagingAssayTemplate", "syn38849300", output_format = "google_sheet")`
# Link downloaded as "ImagingAssayTemplate.csv"
manifest_validate(data_type = "ImagingAssayTemplate", file_name = "ImagingAssayTemplate.csv")
```