### PR TITLE
update annotate_with_manifest

### DIFF
--- a/R/annotations.R
+++ b/R/annotations.R
@@ -21,8 +21,14 @@ annotate_with_manifest <- function(manifest, ignore_na = TRUE, ignore_blank = TR
   filterBlank <- if(ignore_blank) function(x) !any(x == "") else TRUE # same as above
   annotations <- lapply(annotations, function(x) Filter(function(x) filterNA(x) & filterBlank(x) & length(x), unlist(x, recursive = F)))
   for(entity in names(annotations)) {
-    .syn$setAnnotations(entity = entity, annotations = as.list(annotations[[entity]]))
+    
+    old_annots <- synapser::synGetAnnotations(entity)
+    ent <- synapser::synGet(entity, downloadFile = FALSE)
+    ent$annotations <- c(old_annots, annotations[[entity]])
+    synapser::synStore(ent)
+    
   }
+                                                      
   if (verbose) message("Annotations submitted")
 }
 


### PR DESCRIPTION
This is a minor change to fix the annotate_with_manifest function to be compatible with newer versions of synapser