### PR TITLE
Patch - issue 234

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nfportalutils
 Title: NF Portal Utilities
-Version: 0.9700
+Version: 0.9701
 Authors@R: c(
     person(given = "Robert", family = "Allaway", role = c("aut", "cre"),
            email = "robert.allaway@sagebionetworks.org",

--- a/R/cbioportal.R
+++ b/R/cbioportal.R
@@ -112,7 +112,7 @@ cbp_new_study <- function(cancer_study_identifier,
 #'
 #' @param clinical_data Clinical table query.
 #' @param ref_map YAML file specifying the mapping of (NF) clinical metadata to cBioPortal model. See details.
-#' @param clinical_type (Optional) Add as "Sample" or "Patient" clinical data. If not given, will infer which files need to be written.
+#' @param clinical_type (Optional) Add as "SAMPLE" or "PATIENT" clinical data. If not given, will infer which files need to be written.
 #' @param verbose Whether to provide informative messages throughout.
 #'
 #' @export

--- a/R/cboilerplate.R
+++ b/R/cboilerplate.R
@@ -89,10 +89,12 @@ with_selected_elements <- function(df, selectable_elements) {
 #' @inheritParams write_cbio_clinical
 #' @param m A reference mapping object. See `use_ref_map`.
 #' @param clinical_type `SAMPLE` or `PATIENT`
+#' @param na_recode Values considered NA that will be blank strings in cBioPortal's preferred format.
 #' @keywords internal
 as_clinical_file_type <- function(df,
                                   clinical_type = c("SAMPLE", "PATIENT"),
                                   m,
+                                  na_recode = getOption("nfportalutils.na_recode"),
                                   publish_dir = ".",
                                   verbose = TRUE) {
 
@@ -159,7 +161,7 @@ as_clinical_file_type <- function(df,
 write_cbio_clinical <- function(df,
                                 ref_map,
                                 clinical_type = NULL,
-                                na_recode = c("NA", "NaN", "unknown", "Unknown"),
+                                na_recode = getOption("nfportalutils.na_recode"),
                                 delim = "\t",
                                 publish_dir = ".",
                                 verbose = TRUE) {
@@ -172,20 +174,20 @@ write_cbio_clinical <- function(df,
 
   if(is.null(clinical_type)) {
 
-    as_clinical_file_type(df, clinical_type = "SAMPLE", m, publish_dir, verbose = TRUE)
+    as_clinical_file_type(df, clinical_type = "SAMPLE", m, na_recode, publish_dir, verbose = TRUE)
 
-    patient_id <- match_exactly_one("PATIENT_ID", data_elements, m)
-    if(length(sample_id) == 1L) {
-      as_clinical_file_type(df, clinical_type = "patient", m, publish_dir, verbose = TRUE)
+    patient_id <- match_exactly_one("PATIENT_ID", df, m)
+    if(length(patient_id) == 1L) {
+      as_clinical_file_type(df, clinical_type = "PATIENT", m, na_recode, publish_dir, verbose = TRUE)
     }
 
   } else if(clinical_type == "SAMPLE") {
 
-    as_clinical_file_type(df, clinical_type = "SAMPLE", m, publish_dir, verbose = TRUE)
+    as_clinical_file_type(df, clinical_type = "SAMPLE", m, na_recode, publish_dir, verbose = TRUE)
 
   } else if(clinical_type == "PATIENT") {
 
-    as_clinical_file_type(df, clinical_type = "PATIENT", m, publish_dir, verbose = TRUE)
+    as_clinical_file_type(df, clinical_type = "PATIENT", m, na_recode, publish_dir, verbose = TRUE)
     message("Please also remember to add required SAMPLE clinical data if this hasn't already been added.")
 
   } else {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,12 @@
 synapseclient <- NULL
 
+# Default NA recoding values for cBioPortal export
+.default_na_recode <- c("NA", "NaN", "unknown", "Unknown", "UNKNOWN", "NULL", "null", "Null", 
+                        "", " ", ".", "-", "N/A", "n/a", "Not Available", "not available",
+                        "Not Reported", "not reported", "Missing", "missing", "Not Collected", 
+                        "not collected", "Not Applicable", "not applicable", "Pending", "pending", 
+                        "TBD")
+
 .onLoad <- function(libname, pkgname) {
 
   syn_inst <- reticulate::py_module_available("synapseclient")
@@ -14,4 +21,6 @@ synapseclient <- NULL
   pandas_inst <- reticulate::py_module_available("pandas")
   if(!pandas_inst) warning("Python module `pandas` is not available and some package functions may not work.")
   
+  # Set default package options
+  options(nfportalutils.na_recode = .default_na_recode)
 }

--- a/man/as_clinical_file_type.Rd
+++ b/man/as_clinical_file_type.Rd
@@ -8,6 +8,7 @@ as_clinical_file_type(
   df,
   clinical_type = c("SAMPLE", "PATIENT"),
   m,
+  na_recode = getOption("nfportalutils.na_recode"),
   publish_dir = ".",
   verbose = TRUE
 )
@@ -18,6 +19,8 @@ as_clinical_file_type(
 \item{clinical_type}{\code{SAMPLE} or \code{PATIENT}}
 
 \item{m}{A reference mapping object. See \code{use_ref_map}.}
+
+\item{na_recode}{Values considered NA that will be blank strings in cBioPortal's preferred format.}
 
 \item{publish_dir}{Directory path to write to, defaults to current.}
 

--- a/man/cbp_add_clinical.Rd
+++ b/man/cbp_add_clinical.Rd
@@ -11,7 +11,7 @@ cbp_add_clinical(clinical_data, ref_map, clinical_type = NULL, verbose = TRUE)
 
 \item{ref_map}{YAML file specifying the mapping of (NF) clinical metadata to cBioPortal model. See details.}
 
-\item{clinical_type}{(Optional) Add as "Sample" or "Patient" clinical data. If not given, will infer which files need to be written.}
+\item{clinical_type}{(Optional) Add as "SAMPLE" or "PATIENT" clinical data. If not given, will infer which files need to be written.}
 
 \item{verbose}{Whether to provide informative messages throughout.}
 }

--- a/man/write_cbio_clinical.Rd
+++ b/man/write_cbio_clinical.Rd
@@ -8,7 +8,7 @@ write_cbio_clinical(
   df,
   ref_map,
   clinical_type = NULL,
-  na_recode = c("NA", "NaN", "unknown", "Unknown"),
+  na_recode = getOption("nfportalutils.na_recode"),
   delim = "\\t",
   publish_dir = ".",
   verbose = TRUE

--- a/vignettes/exporting-data-to-other-platforms-cbioportal.Rmd
+++ b/vignettes/exporting-data-to-other-platforms-cbioportal.Rmd
@@ -124,13 +124,27 @@ This resource serves several purposes:
 - Provides a mapping that keeps up-to-date with what cBioPortal, e.g. what is patient-only and what is the closest standard variable an NF variable should map to. Sincere effort is given to make data comparable across different public datasets. 
 - Serves as export control; only variables in the list will be exported. Clinical data requires thoughtful selection and documentation of what clinical variables to be made public. The original clinical data on Synapse may possibly contain variables more sensitive than appropriate for cBioPortal, or the original clinical data may contain variables not super relevant for visualization on cBioPortal (e.g. `link_to_WGS_file`).  
 
-**If the current dataset to be exported contains new clinical data, the variables should be reviewed and added to [`ref_map`](https://github.com/nf-osi/nf-metadata-dictionary/blob/main/mappings/cBioPortal/cBioPortal.yaml) as appropriate.** 
-
 While `ref_map` controls the selection of clinical variables, the selection of patients/samples appropriate for the current dataset is done via the query used during this process. That is, the clinical table(s) must sometimes be subsetted to match what is actually released in the current study dataset. For example, if the full clinical cohort table comprises patients 1-50, but the dataset can only release data for patients 1-20 for expression data and data patients 15-20 for CNA data, then use a query that makes selection for patients 1-20 only. In other cases, the selection query may look more like `where batch = 'batch1'`.
 
-First specify `ref_map`. It may be helpful to follow the link to better understand the file.
+Remember to specify `ref_map`. It may be helpful to follow the link to better understand the file.
 ```
 ref_map <- "https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/main/mappings/cBioPortal/cBioPortal.yaml"
+```
+
+##### New clinical variables
+
+If the current dataset to be exported contains new clinical data variables, the variables should be reviewed and added to [`ref_map`](https://github.com/nf-osi/nf-metadata-dictionary/blob/main/mappings/cBioPortal/cBioPortal.yaml) as appropriate.
+
+##### NA value recoding
+
+By default, the package converts a comprehensive set of missing/unknown values to cBioPortal's preferred empty string format. Users can customize which values are treated as NA by setting the package option:
+
+```r
+# View current NA recode values
+getOption("nfportalutils.na_recode")
+
+# Customize NA values (example)
+options(nfportalutils.na_recode = c("NA", "NULL", "missing", "custom_value"))
 ```
 
 #### (Option 1) Export using single source clinical data table

--- a/vignettes/exporting-data-to-other-platforms-cbioportal.Rmd
+++ b/vignettes/exporting-data-to-other-platforms-cbioportal.Rmd
@@ -172,13 +172,16 @@ cbp_add_clinical(cd_patient, ref_map, type = "patient")
 
 ## Validation
 
-Validation has to be done with a cBioPortal instance. Each portal may have specific configurations (such as genomic reference) to validate against.
+Validation has to be done with a cBioPortal instance (use their official Docker image).
 
-For an example simple *offline* validation, assuming you are at `~/datahub/public` and a study folder called `npst_nfosi_ntap_2022` has been placed into it, mount the dataset into the container and run validation like:  
+For an example simple validation, assuming your current wording directory is something like `~/sage/submissions` with a study folder called `npst_nfosi_ntap_2022` run validation like:  
 ```
 STUDY=npst_nfosi_ntap_2022
-sudo docker run --rm -v $(pwd):/datahub cbioportal/cbioportal:6.0.25 validateData.py -s datahub/$STUDY -n -v
+sudo docker run --rm --user $(id -u):$(id -g) -v $(pwd):/studies cbioportal/cbioportal:6.3.2  validateStudies.py -d /studies -n -html /studies -l $STUDY
 ```
+
+A log .txt file as well as prettier .html file for human consumption will be outputted containing validation results. 
+Submission can proceed as along as there are no errors.
 
 **See the [general docs for dataset validation](https://docs.cbioportal.org/using-the-dataset-validator) for more examples.**
 


### PR DESCRIPTION
Fix and make `na_recode` more configurable. Reinstall and test as below. The below is an updated query example to create the cBioPortal clinical data artifact -- in this case, the  sample ids need to be manually selected because only a subset of the cohort appear in the maf or gene expression matrix.

The other approach, if you want to, is to update the table itself to make the query simpler (for example, the table already has `in_acta` to mark which samples appear in the publication; you can add `in_cbp` and use that for a simpler filter query and similar tracking for posterity). 
```
ref_map <- "https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/refs/heads/main/mappings/cBioPortal/cBioPortal.yaml"
clinical_data <- "SELECT * FROM syn26958220 where specimenID in ('SYN_NF_001', 'SYN_NF_002')"
cbp_add_clinical(clinical_data, ref_map = ref_map, clinical_type = "SAMPLE")
cbp_add_clinical(clinical_data, ref_map = ref_map, clinical_type = "PATIENT")
```

Update: Issues with some of Ubuntu runners, but I think this OK to test for now.
