### PR TITLE
Fix login check scope issues in validation functions

### DIFF
--- a/R/login.R
+++ b/R/login.R
@@ -22,9 +22,11 @@ syn_login <- function(authtoken = Sys.getenv("SYNAPSE_AUTH_TOKEN")){
 #' @returns A message.
 #' @keywords internal
 .check_login <- function(){
-  if(!exists(".syn")){
+  if(!exists(".syn", envir = .GlobalEnv)){
     stop('Please run `nfportalutils::syn_login()` prior to running functions that require a connection to Synapse. (Alternatively, the Python `synapseclient` is unavailable.)')
-  }else if(capture.output(.syn) == "<pointer: 0x0>"){
+  }
+  .syn <- get(".syn", envir = .GlobalEnv)
+  if(capture.output(.syn) == "<pointer: 0x0>"){
     stop('Please run `nfportalutils::syn_login()` prior to running functions that require a connection to Synapse. (Alternatively, the Python `synapseclient` is unavailable.)')
   }
 }

--- a/R/validation.R
+++ b/R/validation.R
@@ -27,7 +27,9 @@
 #' bind_schema(id = "syn12345678", schema_id = "org.synapse.nf-rnaseqtemplate-11.0.0")
 #' }
 bind_schema <- function(id, schema_id, derived_annotations = FALSE) {
-  
+
+  .check_login()
+
   bind_schema_request <- jsonlite::toJSON(list(entityId = id,
                                                `schema$id` = schema_id,
                                                enableDerivedAnnotations = derived_annotations),
@@ -92,6 +94,7 @@ is_file <- function(id) {
 #' @param id Entity id.
 #' @export
 validate_bound_entity <- function(id) {
+  .check_login()
   .syn$restGET(glue::glue("https://repo-prod.prod.sagebase.org/repo/v1/entity/{id}/schema/validation"))
 }
 
@@ -148,6 +151,8 @@ validate_entities_parallel <- function(entity_ids, mc.cores = NULL) {
 #' @return A list with `validation_error` component containing any validation errors found for files.
 #' @export
 validate_dataset_folder <- function(id, fileview, mc.cores = NULL) {
+
+  .check_login()
 
   if(missing(fileview) || is.null(fileview)) {
     stop("A fileview is required to query files in the dataset folder.")
@@ -212,6 +217,7 @@ validate_dataset_folder <- function(id, fileview, mc.cores = NULL) {
 #' @export
 #' @aliases validate_dataset_items
 validate_collection_items <- function(collection_id, mc.cores = NULL) {
+  .check_login()
   coll <- .syn$get(collection_id)
   items <- coll$properties$datasetItems
   if(!length(items)) {

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -37,6 +37,9 @@ skip_if_no_token <- function() {
 # (e.g. someone pasted in wrong token), this creates a skip cascade for tests that presume
 # successful login.
 skip_if_no_login <- function() {
-  if(!exists(".syn") || is.null(.syn$username))
+  if(!exists(".syn", envir = .GlobalEnv))
+    skip("not logged in for tests")
+  .syn <- get(".syn", envir = .GlobalEnv)
+  if(is.null(.syn$username))
     skip("not logged in for tests")
 }


### PR DESCRIPTION
## Summary

Fixes `object '.syn' not found` error in validation functions and adds proper login checks with clear error messages.

## Problem

Users experienced `Error: object '.syn' not found` when calling validation functions. This occurred in two scenarios:

1. **Calling validation functions without logging in first**
2. **Using `synapser::synLogin()` instead of `nfportalutils::syn_login()`** ⚠️

The validation functions weren't checking login status, and `.check_login()` wasn't explicitly looking in `.GlobalEnv` for the `.syn` connection object.

## Root Cause

`nfportalutils` uses Python's `synapseclient` (via reticulate) and requires `nfportalutils::syn_login()` to create the `.syn` object. The `synapser` package is a different implementation and creates incompatible login objects.

## Solution

**Fixed environment scoping:**
- Updated `.check_login()` to explicitly check and retrieve `.syn` from `.GlobalEnv` (R/login.R:25-31)
- Updated test helper `skip_if_no_login()` with same fix (tests/testthat/helpers.R:40-44)

**Added missing login checks:**
- `bind_schema()` (R/validation.R:31)
- `validate_bound_entity()` (R/validation.R:97)
- `validate_dataset_folder()` (R/validation.R:155)
- `validate_collection_items()` (R/validation.R:220)

Now these functions provide a clear error message:
```
Error: Please run `nfportalutils::syn_login()` prior to running functions that require a connection to Synapse.
```

## Testing

All existing tests pass:
```
✅ FAIL 0 | WARN 0 | SKIP 20 | PASS 3
```

## Usage Note

Always use `nfportalutils::syn_login()` with this package, not `synapser::synLogin()`:

```r
library(nfportalutils)
syn_login()  # Correct - creates .syn object

# Now validation functions work
bind_schema(id = "syn71723717", schema_id = "org.synapse.nf-superdataset")
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)